### PR TITLE
Removed deprecated bottle :unneeded

### DIFF
--- a/Formula/upterm.rb
+++ b/Formula/upterm.rb
@@ -7,7 +7,6 @@ class Upterm < Formula
   homepage "https://upterm.dev"
   version "0.6.5"
   license "Apache 2.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/owenthereal/upterm/releases/download/v0.6.5/upterm_darwin_amd64.tar.gz"


### PR DESCRIPTION
Homebrew issues following warning:
<img width="970" alt="image" src="https://user-images.githubusercontent.com/2448782/137978377-afe95fc5-9492-4747-a6fb-4d7186c9c68d.png">

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the jingweno/upterm tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/jingweno/homebrew-upterm/Formula/upterm.rb:10
```