### PR TITLE
conflicts_with now deprecated, and emitting warnings

### DIFF
--- a/Casks/upterm.rb
+++ b/Casks/upterm.rb
@@ -43,10 +43,6 @@ cask "upterm" do
     end
   end
 
-  conflicts_with formula: [
-      "upterm",
-    ]
-
   postflight do
     if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
       system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/upterm"]


### PR DESCRIPTION
Since there are no replacements for conflicts_with - see warning - just dropping it